### PR TITLE
Fix swagger URL resolution for newer versions

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,14 @@
+
+function swaggerUrl(version) {
+  //backward compatibility
+  const oldPathVersions = ['v4.1.0', 'v4.2.0', 'v4.2.1', 'v5.0.0-rc.1'];
+  if (oldPathVersions.includes(version)) {
+    return `https://raw.githubusercontent.com/aeternity/aeternity/${version}/config/swagger.yaml`;
+  }
+
+  return `https://raw.githubusercontent.com/aeternity/aeternity/${version}/apps/aehttp/priv/swagger.yaml`;
+}
+
 async function getLatestRelease() {
     return fetch('https://api.github.com/repos/aeternity/aeternity/releases/latest')
       .then(response => response.json())
@@ -24,7 +35,7 @@ async function getSwaggerUrls() {
     return releases.map(v => {
         return {
             name: v,
-            url: `https://raw.githubusercontent.com/aeternity/aeternity/${v}/config/swagger.yaml`
+            url: swaggerUrl(v)
         };
     });
 }


### PR DESCRIPTION
In 5.0.0-rc.2 and current node master the swagger schema location has been changed.